### PR TITLE
Disable simulation for Headless clients to avoid the HC going under the terrain

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Template Básico
+
 Template básico de scripts para misiones ArgA
 
 ### Bengalas en morteros
@@ -10,18 +11,20 @@ Para que funcione el script de aumento de intensidad de las bengalas en los mort
 [this] execVM "core\scripts\flares\activate_mortar.sqf";
 ```
 
-
 ### Actualizar el template basico
+
 1. Crear un PR con los cambios a realizar
 2. Cambiar la version del template en `./core/private_settings.hpp`. Modificar las constantes `TEMPLATE_VERSION` y `TEMPLATE_LAST_UPDATE`
-3. Si el PR es aprobado, mergear a master
-4. Una vez mergeado, borrar la branch
-5. En tu repositorio local, volver a master y hacer un `git pull`
-6. Actualizar la version del template en la base de datos: `UPDATE arga-log.version_template SET version_number = [TEMPLATE_VERSION] and version_date = [TEMPLATE_LAST_UPDATE];`
-
-
+3. Actualizar nombre del template basico:  `./arga_settings.hpp`. Modificar variable `COMPLETE_NAME`
+4. Si el PR es aprobado, mergear a master
+5. Una vez mergeado, borrar la branch
+6. En tu repositorio local, volver a master y hacer un `git pull`
+7. Actualizar la version del template en la base de datos: `UPDATE arga-log.version_template SET version_number = [TEMPLATE_VERSION] and version_date = [TEMPLATE_LAST_UPDATE];`
+8. Si corresponde, actualizar los scripts base de `persistentes-arga`: https://github.com/Clan-ArgA/persistentes-arga. Recordar actualizar `TEMPLATE_VERSION`, `TEMPLATE_LAST_UPDATE` y `COMPLETE_NAME`.
+9. Si corresponde, actualizar los scripts base de `entrenamientos-arga`: https://github.com/Clan-ArgA/entrenamientos-arga. Recordar actualizar `TEMPLATE_VERSION`, `TEMPLATE_LAST_UPDATE` y `COMPLETE_NAME`.
 
 ### Como actualizar el template-basico en el panel manualmente
+
 El panel cuando recibe una solicitud de descarga del template-basico (por ejemplo desde el formulario de misiones), realiza un `git pull` de forma automatica del template, por lo que siempre deberia descargar la ultima version disponible.
 
 Si esto no sucede podemos actualizarlo manualmente:

--- a/arga_settings.hpp
+++ b/arga_settings.hpp
@@ -3,7 +3,7 @@
 *******************************************************************************/
 
 #define NAME "Op. Template Basico"                  // Colocar nombre de mision
-#define COMPLETE_NAME "Op. Template Basico v0.9.19" // Nombre y versión de la misión
+#define COMPLETE_NAME "Op. Template Basico v0.9.22" // Nombre y versión de la misión
 #define IMAGE "imgs\portada.paa"                    // Colocar nombre y extension de la imagen de portada, ej "imgs\portada.jpg"
 #define DESCRIPTION ""                              // Colocar descripcion de la mision entre las comillas
 

--- a/core/events/initPlayerLocal.sqf
+++ b/core/events/initPlayerLocal.sqf
@@ -104,6 +104,9 @@ if(_colorCorrection) then {
     execVM "core\scripts\init_correction_color.sqf";
 };
 
+if (!hasInterface and !isServer) then {
+  player enableSimulation false;
+};
 
 /*******************************************************************************
                              Realizado por |ArgA|MIV

--- a/core/private_settings.hpp
+++ b/core/private_settings.hpp
@@ -2,8 +2,8 @@
                           Realizado por |ArgA|MIV
 *******************************************************************************/
 
-TEMPLATE_VERSION     = "0.9.21";
-TEMPLATE_LAST_UPDATE = "2023-6-29";                  // Escribir la fecha en formato AAAA-M-D sin ceros en el mes o el día.
+TEMPLATE_VERSION     = "0.9.22";
+TEMPLATE_LAST_UPDATE = "2024-4-27";                  // Escribir la fecha en formato AAAA-M-D sin ceros en el mes o el día.
 
 /* Log system */
 DEBUG = 1;                                          // 1: Habilita el modo debug, 0: Deshabilita.


### PR DESCRIPTION
Change for training base scripts: https://github.com/Clan-ArgA/entrenamientos-arga/pull/1
Change for persistent missions: https://github.com/Clan-ArgA/persistentes-arga/pull/1

Closes https://github.com/Clan-ArgA/template-basico/issues/28